### PR TITLE
[FEAT] 지평좌표계 x, y, z 좌표로 변환 구현

### DIFF
--- a/Tars/Tars/Model/Body.swift
+++ b/Tars/Tars/Model/Body.swift
@@ -13,6 +13,7 @@ struct Body: Decodable {
     var distanceFromEarth: String
     var altitude: String
     var azimuth: String
+    var coordinate: (x: Float, y: Float, z: Float)
 
     enum CodingKeys: String, CodingKey {
         case cells, id, name, distance, position
@@ -38,5 +39,17 @@ extension Body {
         self.distanceFromEarth = try fromEarth.decode(String.self, forKey: .km)
         self.altitude = try altitude.decode(String.self, forKey: .degrees)
         self.azimuth = try azimuth.decode(String.self, forKey: .degrees)
+        self.coordinate = Self.horizontalCoordinateToXYZ(azimuth: self.azimuth, altitude: self.altitude)
+    }
+
+    private static func horizontalCoordinateToXYZ(azimuth: String, altitude: String) -> (x: Float, y: Float, z: Float) {
+        let azimuth = (azimuth as NSString).floatValue
+        let altitude = (altitude as NSString).floatValue
+        
+        let x = cos(altitude) * sin(azimuth)
+        let y = cos(altitude) * cos(azimuth)
+        let z = sin(altitude)
+        
+        return (x, y, z)
     }
 }


### PR DESCRIPTION
## 관련 이슈
#12
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->


## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] Body 모델 x,y,z 프로퍼티 추가
- [x] 지평좌표계에서 x, y, z 좌표로 변환하는 함수 추가

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- API에서 값을 받아와 decode 할 때 변환해서 coordinate에 저장하도록 했습니다.

## Reference
<!-- 참고한 자료를 작성해주세요 -->
https://math.stackexchange.com/questions/4433526/how-to-get-3d-coordinates-xyz-of-the-sun-given-azimuth-and-altitude-elevation

## Checklist
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인


