### PR TITLE
[FIX] 지평 좌표계 x,y,z 변환 수정

### DIFF
--- a/Tars/Tars/Model/Body.swift
+++ b/Tars/Tars/Model/Body.swift
@@ -47,8 +47,8 @@ extension Body {
         let altitude = (altitude as NSString).floatValue
         
         let x = cos(altitude) * sin(azimuth)
-        let y = cos(altitude) * cos(azimuth)
-        let z = sin(altitude)
+        let y = sin(altitude)
+        let z = -(cos(altitude) * cos(azimuth))
         
         return (x, y, z)
     }


### PR DESCRIPTION
## 관련 이슈
#22 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 사용할 좌표계와 변환 좌표계가 달라 재계산 후 함수 변경

## Reference
<!-- 참고한 자료를 작성해주세요 -->
https://en.wikipedia.org/wiki/Horizontal_coordinate_system
https://developer.apple.com/documentation/arkit/arconfiguration/worldalignment/gravityandheading

## Checklist
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인


