### PR TITLE
[FIX] 권한 설정 후 최초 실행시 행성 위치 정보를 못받는 버그 수정

### DIFF
--- a/Tars/Tars.xcodeproj/project.pbxproj
+++ b/Tars/Tars.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		37024B0F2912083E00BC64AE /* LocationManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37024B0E2912083E00BC64AE /* LocationManagerDelegate.swift */; };
 		374FEE372909597B00E0C56B /* Float+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374FEE362909597B00E0C56B /* Float+Extension.swift */; };
 		55C8495A2910A9F00041F334 /* PlanetList+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C849592910A9F00041F334 /* PlanetList+Extension.swift */; };
 		55F3B9AC290FA1FE0033041E /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F3B9AB290FA1FE0033041E /* Keys.swift */; };
@@ -40,6 +41,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		37024B0E2912083E00BC64AE /* LocationManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManagerDelegate.swift; sourceTree = "<group>"; };
 		374FEE362909597B00E0C56B /* Float+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Float+Extension.swift"; sourceTree = "<group>"; };
 		55C849592910A9F00041F334 /* PlanetList+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlanetList+Extension.swift"; sourceTree = "<group>"; };
 		55F3B9AB290FA1FE0033041E /* Keys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
@@ -85,12 +87,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		37024B0D2912082500BC64AE /* Location */ = {
+			isa = PBXGroup;
+			children = (
+				BF6BCBAB29090E180042B522 /* LocationManager.swift */,
+				37024B0E2912083E00BC64AE /* LocationManagerDelegate.swift */,
+			);
+			path = Location;
+			sourceTree = "<group>";
+		};
 		37AE64B82906B766000ABC86 /* Network */ = {
 			isa = PBXGroup;
 			children = (
 				BF6BCBA729090E0E0042B522 /* APIManager.swift */,
 				BF6BCBA929090E120042B522 /* Endpoint.swift */,
-				BF6BCBAB29090E180042B522 /* LocationManager.swift */,
 				BF6BCBAD29090E1C0042B522 /* NetworkService.swift */,
 				37AE64BF2906BCA5000ABC86 /* Base */,
 			);
@@ -138,6 +148,7 @@
 				BF7B4FCC28FE448000F83158 /* ViewController */,
 				BF7B4FCA28FE447000F83158 /* View */,
 				BF7B4FCE28FE44D000F83158 /* Extensions */,
+				37024B0D2912082500BC64AE /* Location */,
 				37AE64B82906B766000ABC86 /* Network */,
 				BF7B4FB528FE431900F83158 /* AppDelegate.swift */,
 				BF7B4FB728FE431900F83158 /* SceneDelegate.swift */,
@@ -301,6 +312,7 @@
 				BF6BCBAE29090E1C0042B522 /* NetworkService.swift in Sources */,
 				BF6BCBA629090E060042B522 /* URLConstants.swift in Sources */,
 				BF788B842903D3BB002BF8C0 /* CommonVariables+Extension.swift in Sources */,
+				37024B0F2912083E00BC64AE /* LocationManagerDelegate.swift in Sources */,
 				55C8495A2910A9F00041F334 /* PlanetList+Extension.swift in Sources */,
 				55F3B9B3290FA2D50033041E /* SelectPlanetCollectionViewCell.swift in Sources */,
 				55F3B9B0290FA2930033041E /* ContentsViewController.swift in Sources */,

--- a/Tars/Tars.xcodeproj/project.pbxproj
+++ b/Tars/Tars.xcodeproj/project.pbxproj
@@ -454,7 +454,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = D9CAJN27UH;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Tars/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라를 사용하기 위해 권한이 필요합니다.";
@@ -484,7 +484,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = D9CAJN27UH;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Tars/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라를 사용하기 위해 권한이 필요합니다.";

--- a/Tars/Tars/Location/LocationManager.swift
+++ b/Tars/Tars/Location/LocationManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import CoreLocation
-import UIKit
 
 enum LocationError: Error {
     case currentLocationFailure
@@ -25,6 +24,8 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         super.init()
         locationManager.delegate = self
     }
+    
+    // MARK: - CLLocationManagerDelegate
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if !isLocationUpdated {
@@ -55,6 +56,8 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         }
     }
     
+    // MARK: - LocationManager method
+
     func updateLocation() {
         if locationManager.authorizationStatus == .authorizedWhenInUse {
             locationManager.startUpdatingLocation()
@@ -80,27 +83,5 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         guard let delegate = delegate else { return }
         delegate.openSetting()
 
-    }
-}
-
-protocol LocationManagerDelegate: AnyObject, UIViewController {
-    func didUpdateUserLocation()
-}
-
-extension LocationManagerDelegate {
-    // TODO: - 임시로 설정한 message 변경
-    func openSetting() {
-        let alert = UIAlertController(title: "위치 서비스 사용", message: "위치서비스를 사용할 수 없습니다. 기기의 설정 > SpaceOver > 위치에서 위치 서비스를 켜주세요", preferredStyle: .alert)
-        let defaultAction = UIAlertAction(title: "설정으로 이동", style: .default, handler: { _ in
-            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-            DispatchQueue.main.async {
-                UIApplication.shared.open(url)
-            }
-        })
-        let destructiveAction = UIAlertAction(title: "취소", style: .destructive, handler: nil)
-        
-        alert.addAction(destructiveAction)
-        alert.addAction(defaultAction)
-        present(alert, animated: true, completion: nil)
     }
 }

--- a/Tars/Tars/Location/LocationManagerDelegate.swift
+++ b/Tars/Tars/Location/LocationManagerDelegate.swift
@@ -5,7 +5,6 @@
 //  Created by 이윤영 on 2022/11/02.
 //
 
-import Foundation
 import UIKit
 
 protocol LocationManagerDelegate: AnyObject, UIViewController {

--- a/Tars/Tars/Location/LocationManagerDelegate.swift
+++ b/Tars/Tars/Location/LocationManagerDelegate.swift
@@ -1,0 +1,31 @@
+//
+//  LocationManagerDelegate.swift
+//  Tars
+//
+//  Created by 이윤영 on 2022/11/02.
+//
+
+import Foundation
+import UIKit
+
+protocol LocationManagerDelegate: AnyObject, UIViewController {
+    func didUpdateUserLocation()
+}
+
+extension LocationManagerDelegate {
+    // TODO: - 임시로 설정한 message 변경
+    func openSetting() {
+        let alert = UIAlertController(title: "위치 서비스 사용", message: "위치서비스를 사용할 수 없습니다. 기기의 설정 > SpaceOver > 위치에서 위치 서비스를 켜주세요", preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: "설정으로 이동", style: .default, handler: { _ in
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            DispatchQueue.main.async {
+                UIApplication.shared.open(url)
+            }
+        })
+        let destructiveAction = UIAlertAction(title: "취소", style: .destructive, handler: nil)
+        
+        alert.addAction(destructiveAction)
+        alert.addAction(defaultAction)
+        present(alert, animated: true, completion: nil)
+    }
+}

--- a/Tars/Tars/Network/APIManager.swift
+++ b/Tars/Tars/Network/APIManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class AstronomyAPIManager: NetworkService {
-    func fetchBodies() async throws -> [Body] {
+    func requestBodies() async throws -> [Body] {
         let parameters = try getBodiesPositionsParameters()
         let url = AstronomyURL.bodiesPosition
         let endpoint = url.getEndpoint(with: parameters)

--- a/Tars/Tars/Network/APIManager.swift
+++ b/Tars/Tars/Network/APIManager.swift
@@ -32,7 +32,7 @@ extension AstronomyAPIManager {
         parameters["time"] =  String(currentTime)
         
         // Get current Location
-        let locationManager = LocationManager()
+        let locationManager = LocationManager.shared
         guard let (latitude, longtitude, elevation) = locationManager.getCurrentLocation() else { throw LocationError.currentLocationFailure}
         parameters["latitude"] = String(latitude)
         parameters["longitude"] = String(longtitude)

--- a/Tars/Tars/Network/LocationManager.swift
+++ b/Tars/Tars/Network/LocationManager.swift
@@ -13,10 +13,6 @@ enum LocationError: Error {
     case currentLocationFailure
 }
 
-protocol LocationManagerDelegate: AnyObject, UIViewController {
-    func didUpdateUserLocation()
-}
-
 class LocationManager: NSObject, CLLocationManagerDelegate {
     static let shared = LocationManager()
     weak var delegate: LocationManagerDelegate?
@@ -51,7 +47,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         case .authorizedWhenInUse:
             manager.startUpdatingLocation()
         case .restricted, .denied:
-            print("authorization restricted or denied")
+            openSetting()
         case .notDetermined:
             manager.requestWhenInUseAuthorization()
         default:
@@ -78,6 +74,33 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     private func didUpdateUserLocation() {
         guard let delegate = delegate else { return }
         delegate.didUpdateUserLocation()
-        print("updateUserLocation()")
+    }
+    
+    private func openSetting() {
+        guard let delegate = delegate else { return }
+        delegate.openSetting()
+
+    }
+}
+
+protocol LocationManagerDelegate: AnyObject, UIViewController {
+    func didUpdateUserLocation()
+}
+
+extension LocationManagerDelegate {
+    // TODO: - 임시로 설정한 message 변경
+    func openSetting() {
+        let alert = UIAlertController(title: "위치 서비스 사용", message: "위치서비스를 사용할 수 없습니다. 기기의 설정 > SpaceOver > 위치에서 위치 서비스를 켜주세요", preferredStyle: .alert)
+        let defaultAction = UIAlertAction(title: "설정으로 이동", style: .default, handler: { _ in
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            DispatchQueue.main.async {
+                UIApplication.shared.open(url)
+            }
+        })
+        let destructiveAction = UIAlertAction(title: "취소", style: .destructive, handler: nil)
+        
+        alert.addAction(destructiveAction)
+        alert.addAction(defaultAction)
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/Tars/Tars/Network/LocationManager.swift
+++ b/Tars/Tars/Network/LocationManager.swift
@@ -7,13 +7,19 @@
 
 import Foundation
 import CoreLocation
+import UIKit
 
 enum LocationError: Error {
     case currentLocationFailure
 }
 
+protocol LocationManagerDelegate: AnyObject, UIViewController {
+    func didUpdateUserLocation()
+}
+
 class LocationManager: NSObject, CLLocationManagerDelegate {
     static let shared = LocationManager()
+    weak var delegate: LocationManagerDelegate?
 
     private let locationManager = CLLocationManager()
     private var location: CLLocation?
@@ -31,6 +37,8 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
             manager.stopUpdatingLocation()
             let location = locations[locations.count - 1]
             self.location = location
+            
+            didUpdateUserLocation()
         }
     }
     
@@ -65,5 +73,11 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
         let longtitude = location.coordinate.longitude
         let altitude = location.altitude
         return (latitude, longtitude, altitude)
+    }
+    
+    private func didUpdateUserLocation() {
+        guard let delegate = delegate else { return }
+        delegate.didUpdateUserLocation()
+        print("updateUserLocation()")
     }
 }

--- a/Tars/Tars/ViewController/UniverseViewController.swift
+++ b/Tars/Tars/ViewController/UniverseViewController.swift
@@ -29,6 +29,8 @@ class UniverseViewController: UIViewController, ARSCNViewDelegate {
         
         selectedSquareView.isHidden = true
         
+        let locationManager = LocationManager.shared
+        locationManager.updateLocation()
         Task {
             let bodies = try await AstronomyAPIManager().requestBodies()
             setPlanetPosition(to: sceneView.scene, planets: bodies)
@@ -100,5 +102,4 @@ class UniverseViewController: UIViewController, ARSCNViewDelegate {
         // Reset tracking and/or remove existing anchors if consistent tracking is required
         
     }
-    
 }

--- a/Tars/Tars/ViewController/UniverseViewController.swift
+++ b/Tars/Tars/ViewController/UniverseViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SceneKit
 import ARKit
 
-class UniverseViewController: UIViewController, ARSCNViewDelegate {
+class UniverseViewController: UIViewController, ARSCNViewDelegate, LocationManagerDelegate {
     
     public var guideCircleView = CustomCircleView()
     public var selectedSquareView = CustomSquareView()
@@ -30,11 +30,8 @@ class UniverseViewController: UIViewController, ARSCNViewDelegate {
         selectedSquareView.isHidden = true
         
         let locationManager = LocationManager.shared
+        locationManager.delegate = self
         locationManager.updateLocation()
-        Task {
-            let bodies = try await AstronomyAPIManager().requestBodies()
-            setPlanetPosition(to: sceneView.scene, planets: bodies)
-        }
     }
     
     /// 행성을 배치하기 위한 함수
@@ -102,4 +99,14 @@ class UniverseViewController: UIViewController, ARSCNViewDelegate {
         // Reset tracking and/or remove existing anchors if consistent tracking is required
         
     }
+    
+    // MARK: - LocationManagerDelegate
+    
+    func didUpdateUserLocation() {
+        Task {
+            let bodies = try await AstronomyAPIManager().requestBodies()
+            setPlanetPosition(to: sceneView.scene, planets: bodies)
+        }
+    }
+    
 }

--- a/Tars/Tars/ViewController/UniverseViewController.swift
+++ b/Tars/Tars/ViewController/UniverseViewController.swift
@@ -30,7 +30,7 @@ class UniverseViewController: UIViewController, ARSCNViewDelegate {
         selectedSquareView.isHidden = true
         
         Task {
-            let bodies = try await AstronomyAPIManager().fetchBodies()
+            let bodies = try await AstronomyAPIManager().requestBodies()
             setPlanetPosition(to: sceneView.scene, planets: bodies)
         }
     }


### PR DESCRIPTION
## 관련 이슈
#34 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->


## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 권한 설정 후 행성 위치 정보를 가져오도록 변경
- [x] location authorization이 restricted이거나 denied 상태일 때 app setting으로 이동하는 알람 띄우도록 구현
- [x] requestLocation으로 위치를 받아올 때 시간이 오래 걸려서 startUpdatingLocation, stopUpdatingLocation으로 변경

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- requestLocation으로 받아오던 위치 정보를 startUpdatingLocatioin, stopUpdatingLocation으로 변경했습니다. 위치 정보를 딱 한번 받아오기 위해서 isLocationUpdated 플래그를 사용했습니다. [c9502e0](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-TARS/commit/c9502e0fa95a5f09749ec0a22a1edffac3fc9006)
- 권한 설정 후 행성 위치 정보를 가져오도록 했습니다. location이 업데이트 되면 didUpdateUserLocation에서 설정한 동작 (requestBodies후 행성 위치 설정)을 실행합니다. [d708df6](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-TARS/commit/d708df63a40665de1770796a0965207512a55a1d)
- 위치 권한이 restricted이거나 denied 상태일 때 app setting으로 이동하도록 했습니다. [c1f3d85](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-TARS/commit/c1f3d8518f8b702f0e1b87ecd8f331b05d46b33e)
 
https://user-images.githubusercontent.com/58019653/199256150-e9d0740d-4159-4d66-90eb-29a6feda2eca.MP4

## Reference
https://developer.apple.com/documentation/corelocation/requesting_authorization_to_use_location_services
https://www.blueswt.com/128
https://stackoverflow.com/questions/48041459/cllocationmanagerdelegate-singleton
https://bestpractiseios.blogspot.com/2017/01/global-locationmanager-singleton-class.html?showComment=1528096667133#c7782944110802258286
<!-- 참고한 자료를 작성해주세요 -->


## Checklist
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인


