### PR TITLE
[FEAT] 컴포넌트와 행성탐지 시  VoiceOver 기능 구현

### DIFF
--- a/Tars/Tars/SearchView/UniverseSearchViewController+DataSource.swift
+++ b/Tars/Tars/SearchView/UniverseSearchViewController+DataSource.swift
@@ -26,6 +26,10 @@ extension UniverseSearchViewController: UICollectionViewDataSource {
         cell.planetNameLabel.text = selectedPlanetName
         cell.planetImageView.image = selectedPlanetImage
         
+        // VoiceOver 처리
+        cell.isAccessibilityElement = true
+        cell.accessibilityValue = cell.planetNameLabel.text
+        
         return cell
     }
     

--- a/Tars/Tars/ViewController/InfoViewController.swift
+++ b/Tars/Tars/ViewController/InfoViewController.swift
@@ -48,6 +48,9 @@ class InfoViewController: UIViewController {
         sceneView.autoenablesDefaultLighting = true
         sceneView.scene = scene
         
+        sceneView.isAccessibilityElement = true
+        sceneView.accessibilityLabel = "\(planet.planetKoreanName) 이미지"
+        
         return sceneView
     }()
     

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -276,7 +276,7 @@ extension UniverseSearchViewController {
             self.guideCircleView.isHidden = true
             self.selectedSquareView.isHidden = false
             self.selectedSquareView.isAccessibilityElement = true
-            self.selectedSquareView.accessibilityLabel = planetNameDict[name] ?? name
+//            self.selectedSquareView.accessibilityLabel = planetNameDict[name] ?? name
         }
     }
     
@@ -303,7 +303,9 @@ extension UniverseSearchViewController {
     
     // 행성 detect되었을 때 announce
     private func guideDetectedAnnounce(name: String) {
+        UIAccessibility.post(notification: .layoutChanged, argument: selectedSquareView)
         UIAccessibility.post(notification: .announcement, argument: planetNameDict[name] ?? name)
+    
     }
 }
 

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -44,6 +44,14 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
     var planetObjectSound: [String: SCNAudioPlayer] = [:]
     var circleCenter: CGPoint = .zero
     
+    var detectedNode: String = "" {
+            didSet {
+                if oldValue != detectedNode && detectedNode != "" {
+                    guideDetectedAnnounce(name: detectedNode)
+                }
+            }
+        }
+    
     let searchGuideLabel: UILabel = {
         let label: UILabel = UILabel()
         label.text = "빠르게 천체 찾기"
@@ -252,6 +260,7 @@ extension UniverseSearchViewController {
     
     // 행성이 탐지되지 않았을 때 레이아웃 설정
     private func setNotDetectedLayout() {
+        detectedNode = ""
         DispatchQueue.main.async {
             self.guideCircleView.isHidden = false
             self.selectedSquareView.isHidden = true
@@ -260,11 +269,14 @@ extension UniverseSearchViewController {
 
     // 행성이 탐지되었을 때 레이아웃 설정
     private func setDetectedLayout(name: String, point: CGPoint) {
+        detectedNode = name
         DispatchQueue.main.async {
             self.selectedSquareView.frame.origin = point
             self.selectedSquareView.setLabel(planetNameDict[name] ?? name)
             self.guideCircleView.isHidden = true
             self.selectedSquareView.isHidden = false
+            self.selectedSquareView.isAccessibilityElement = true
+            self.selectedSquareView.accessibilityLabel = planetNameDict[name] ?? name
         }
     }
     
@@ -287,6 +299,11 @@ extension UniverseSearchViewController {
         DispatchQueue.main.async {
             self.guideArrowView.isHidden = true
         }
+    }
+    
+    // 행성 detect되었을 때 announce
+    private func guideDetectedAnnounce(name: String) {
+        UIAccessibility.post(notification: .announcement, argument: planetNameDict[name] ?? name)
     }
 }
 

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -87,6 +87,8 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
         [coachingBackgroundOverlayView, coachingOverlayView, sceneView, selectPlanetCollectionView, searchGuideLabel].forEach { view.addSubview($0) }
         configureConstraints()
         
+        self.accessibilityElements = [selectPlanetCollectionView]
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 7.0) {
             self.coachingOverlayView.isAccessibilityElement = false
             self.coachingOverlayView.removeFromSuperview()

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -276,6 +276,8 @@ extension UniverseSearchViewController {
             self.guideCircleView.isHidden = true
             self.selectedSquareView.isHidden = false
             self.selectedSquareView.isAccessibilityElement = true
+            
+//추후 사용예정 주석
 //            self.selectedSquareView.accessibilityLabel = planetNameDict[name] ?? name
         }
     }

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -47,6 +47,7 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
     let searchGuideLabel: UILabel = {
         let label: UILabel = UILabel()
         label.text = "빠르게 천체 찾기"
+        label.accessibilityHint = "찾고싶은 천체를 선택해보세요"
         label.textColor = .white
         label.textAlignment = .center
         label.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
@@ -105,6 +106,7 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
             
             // settingButton navigationItem
             self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "gearshape.fill"), style: .plain, target: self, action: #selector(self.settingButtonTapped))
+            self.navigationItem.rightBarButtonItem?.accessibilityLabel = "설정"
             self.navigationItem.rightBarButtonItem?.tintColor = .white
             self.navigationItem.hidesBackButton = true
         }


### PR DESCRIPTION
## 관련 이슈
#14 

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 필요한 컴포넌트에 알맞은 보이스오버
- [x] 탐지되는 행성에 보이스오버 announcing 및 focusing
- [x] 보이스 오버가 의도한 순서대로 흘러가도록 설정

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

<img width="250" src="https://user-images.githubusercontent.com/96990839/203484767-f7244add-f8dc-4b0e-b408-2bdc253065b2.mp4">


## 추후 진행할 사항
보이스오버 전체 UX 점검
<!-- 추후에 진행할 사항들에 대해 적어주세요. -->


## 리뷰포인트
1. 보이스오버가 의도한 UX 순서대로 작동합니다.
2. 보이스오버가 필요한 모든 컴포넌트에서 보이스오버가 작동합니다.
3. 행성 탐지 시 행성을 announce를 해주고 selectedSquare를 focus 잡아줍니다.
4. 보이스오버 focus된 행성을 더블 탭시 상세정보로 넘어갑니다.
5. UniverseSearchViewController에 주석은 추후 사용 가능성을 위해 남겨두었습니다.
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->


## Reference
<!-- 참고한 자료를 작성해주세요 -->


## Checklist
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인


