### PR TITLE
[FEAT] 행성 검색 시 방향 안내 보이스 추가

### DIFF
--- a/Tars/Tars/Extensions/Float+Extension.swift
+++ b/Tars/Tars/Extensions/Float+Extension.swift
@@ -12,5 +12,6 @@ extension Float {
 }
 
 extension FloatingPoint {
+    var degreeToRadians: Self { self * .pi / 180 }
     var radiansToDegree: Self { self * 180 / .pi }
 }

--- a/Tars/Tars/Extensions/Float+Extension.swift
+++ b/Tars/Tars/Extensions/Float+Extension.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 extension Float {
-    func degreeToRadian() -> Float {
-        return self * .pi / 180
-    }
+    var degreeToRadian: Self { self * .pi / 180 }
+}
+
+extension FloatingPoint {
+    var radiansToDegree: Self { self * 180 / .pi }
 }

--- a/Tars/Tars/Model/Body.swift
+++ b/Tars/Tars/Model/Body.swift
@@ -43,8 +43,8 @@ extension Body {
     }
 
     private static func horizontalCoordinateToXYZ(azimuth: String, altitude: String) -> (x: Float, y: Float, z: Float) {
-        let azimuth = (azimuth as NSString).floatValue.degreeToRadian()
-        let altitude = (altitude as NSString).floatValue.degreeToRadian()
+        let azimuth = (azimuth as NSString).floatValue.degreeToRadian
+        let altitude = (altitude as NSString).floatValue.degreeToRadian
         
         let x = 5 * cos(altitude) * sin(azimuth)
         let y = 5 * sin(altitude)

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -10,20 +10,6 @@ import SceneKit
 import ARKit
 import AVFoundation
 
-enum Mode {
-    case explore
-    case search(planet: String)
-    
-    var titleText: String {
-        switch self {
-        case .explore:
-            return "우주 둘러보기"
-        case .search(planet: let name):
-            return "\(planetNameDict[name] ?? name) 찾는 중"
-        }
-    }
-}
-
 class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, LocationManagerDelegate, UIGestureRecognizerDelegate {
 
     private var guideCircleView = CustomCircleView()
@@ -354,6 +340,69 @@ extension UniverseSearchViewController {
         UIAccessibility.post(notification: .layoutChanged, argument: selectedSquareView)
         UIAccessibility.post(notification: .announcement, argument: planetNameDict[name] ?? name)
     
+    }
+}
+
+// MARK: - enum
+extension UniverseSearchViewController {
+    enum Mode {
+        case explore
+        case search(planet: String)
+        
+        var titleText: String {
+            switch self {
+            case .explore:
+                return "우주 둘러보기"
+            case .search(planet: let name):
+                return "\(planetNameDict[name] ?? name) 찾는 중"
+            }
+        }
+    }
+    
+    enum Cardinal: Int {
+        case N = 0
+        case NE = 1
+        case E = 2
+        case SE = 3
+        case S = 4
+        case SW = 5
+        case W = 6
+        case NW = 7
+        case None
+        
+        func isNear(new: Cardinal) -> Bool {
+            if new == .None {
+                return true
+            } else if self == .None {
+                return false
+            } else {
+                let difference = abs(self.rawValue - new.rawValue) % 7
+                return difference <= 1
+            }
+        }
+        
+        var directionText: String {
+            switch self {
+            case .N:
+                return "위로"
+            case .NE:
+                return "오른쪽 위로"
+            case .E:
+                return "오른쪽으로"
+            case .SE:
+                return "오른쪽 아래로"
+            case .S:
+                return "아래로"
+            case .SW:
+                return "왼쪽 아래로"
+            case .W:
+                return "왼쪽으로"
+            case .NW:
+                return "왼쪽 위로"
+            default:
+                return ""
+            }
+        }
     }
 }
 

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -315,18 +315,34 @@ extension UniverseSearchViewController {
     }
     
     // 검색 시 화살표 레이아웃 설정
-    private func setArrowLayout(point: CGPoint, distance: CGFloat, locatedBehind: Bool = false) {
-        let dx = screenWidth / 3  * (point.x - circleCenter.x) / distance
-        let dy = screenWidth / 3  * (circleCenter.y - point.y) / distance
-        let angle = locatedBehind ? atan2(point.y - circleCenter.y, point.x - circleCenter.x) + .pi : atan2(point.y - circleCenter.y, point.x - circleCenter.x)
-        let arrowPosition = locatedBehind ? CGPoint(x: circleCenter.x - dx, y: circleCenter.y + dy) : CGPoint(x: circleCenter.x + dx, y: circleCenter.y - dy)
-                
-        DispatchQueue.main.async {
-            self.guideArrowView.transform = CGAffineTransform(rotationAngle: angle)
-            self.guideArrowView.layer.position = arrowPosition
-            self.guideArrowView.isHidden = false
+    private func setArrowLayout(point: CGPoint, locatedBehind: Bool = false) {
+            let radian = locatedBehind ? atan2(circleCenter.y - point.y, point.x - circleCenter.x)
+            + .pi : atan2(circleCenter.y - point.y, point.x - circleCenter.x)
+            var degree = radian.radiansToDegree
+            
+            if locatedBehind {
+                if degree > 45 && degree <= 90 {
+                    degree = 45
+                } else if degree > 90 && degree < 135 {
+                    degree = 135
+                } else if degree > 225 && degree < 270 {
+                    degree = 225
+                } else if degree < 315 && degree >= 270 {
+                    degree = 315
+                }
+            }
+            
+            let dx = screenWidth / 3  * cos(radian)
+            let dy = screenWidth / 3  * sin(radian)
+            let arrowPosition = CGPoint(x: circleCenter.x + dx, y: circleCenter.y - dy)
+            
+            DispatchQueue.main.async {
+                self.guideArrowView.transform = CGAffineTransform(rotationAngle: -radian)
+                self.guideArrowView.layer.position = arrowPosition
+                self.guideArrowView.isHidden = false
+            }
+            
         }
-    }
     
     // 화살표 숨김 설정
     private func setArrowHidden() {
@@ -456,11 +472,11 @@ extension UniverseSearchViewController {
         if nodePosition.z >= 1 {
             // 찾는 노드가 뒤에 있을 때
             setNotDetectedLayout()
-            setArrowLayout(point: nodeScreenPos, distance: distanceToCenter, locatedBehind: true)
+            setArrowLayout(point: nodeScreenPos, locatedBehind: true)
         } else if distanceToCenter >= (screenWidth / 3) {
             // 찾는 노드가 원의 바깥에 있을 때
             setNotDetectedLayout()
-            setArrowLayout(point: nodeScreenPos, distance: distanceToCenter)
+            setArrowLayout(point: nodeScreenPos)
         } else {
             // 찾는 노드가 원 안에 있을 때
             let nodeOrigin = CGPoint(x: nodeScreenPos.x - screenWidth / 11.3, y: nodeScreenPos.y - screenWidth / 11.3)

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -346,7 +346,8 @@ extension UniverseSearchViewController {
         let dx = screenWidth / 3  * cos(radian)
         let dy = screenWidth / 3  * sin(radian)
         let arrowPosition = CGPoint(x: circleCenter.x + dx, y: circleCenter.y - dy)
-        
+        arrowCardinal = getCardinal(angle: degree)
+
         DispatchQueue.main.async {
             self.guideArrowView.transform = CGAffineTransform(rotationAngle: -radian)
             self.guideArrowView.layer.position = arrowPosition

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -316,7 +316,7 @@ extension UniverseSearchViewController {
     
     // 검색 시 화살표 레이아웃 설정
     private func setArrowLayout(point: CGPoint, locatedBehind: Bool = false) {
-            let radian = locatedBehind ? atan2(circleCenter.y - point.y, point.x - circleCenter.x)
+            var radian = locatedBehind ? atan2(circleCenter.y - point.y, point.x - circleCenter.x)
             + .pi : atan2(circleCenter.y - point.y, point.x - circleCenter.x)
             var degree = radian.radiansToDegree
             
@@ -330,6 +330,7 @@ extension UniverseSearchViewController {
                 } else if degree < 315 && degree >= 270 {
                     degree = 315
                 }
+                radian = degree.degreeToRadians
             }
             
             let dx = screenWidth / 3  * cos(radian)

--- a/Tars/Tars/ViewController/UniverseSearchViewController.swift
+++ b/Tars/Tars/ViewController/UniverseSearchViewController.swift
@@ -11,7 +11,7 @@ import ARKit
 import AVFoundation
 
 class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, LocationManagerDelegate, UIGestureRecognizerDelegate {
-
+    
     private var guideCircleView = CustomCircleView()
     private var selectedSquareView = CustomSquareView()
     private var guideArrowView = CustomArrowView()
@@ -31,13 +31,13 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
     var circleCenter: CGPoint = .zero
     
     var detectedNode: String = "" {
-            didSet {
-                if oldValue != detectedNode && detectedNode != "" {
-                    guideDetectedAnnounce(name: detectedNode)
-                }
+        didSet {
+            if oldValue != detectedNode && detectedNode != "" {
+                guideDetectedAnnounce(name: detectedNode)
             }
         }
-
+    }
+    
     var announceCardinal: Cardinal = .None
     var arrowCardinal: Cardinal = .None {
         didSet {
@@ -80,7 +80,7 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
         sceneView.delegate = self
         return sceneView
     }()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -124,7 +124,7 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
         let locationManager = LocationManager.shared
         locationManager.delegate = self
         locationManager.updateLocation()
-
+        
         var result: Bool = checkAuthorization()
         
         // 권한을 체크해서 허용인 경우에만 overlay뷰가 없어지도록 구현
@@ -233,13 +233,13 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
         
         coachingBackgroundOverlayView.layer.zPosition = 1
         self.navigationController?.navigationBar.layer.zPosition = -1
-
+        
         guideCircleView.centerX(inView: view)
         guideCircleView.anchor(top: view.topAnchor, paddingTop: screenHeight * 0.23)
         
         searchGuideLabel.centerX(inView: view)
         searchGuideLabel.anchor(top: view.topAnchor, paddingTop: screenHeight * 0.7)
-
+        
         selectPlanetCollectionView.anchor(top: view.topAnchor, paddingTop: screenHeight * 0.68)
         selectPlanetCollectionView.setHeight(height: screenHeight * 0.35)
         selectPlanetCollectionView.setWidth(width: screenWidth)
@@ -266,7 +266,7 @@ class UniverseSearchViewController: UIViewController, ARSCNViewDelegate, Locatio
         super.viewWillDisappear(animated)
         sceneView.session.pause()
     }
-
+    
     // MARK: - LocationManagerDelegate
     func didUpdateUserLocation() {
         Task {
@@ -308,7 +308,7 @@ extension UniverseSearchViewController {
             self.selectedSquareView.isHidden = true
         }
     }
-
+    
     // 행성이 탐지되었을 때 레이아웃 설정
     private func setDetectedLayout(name: String, point: CGPoint) {
         detectedNode = name
@@ -319,41 +319,41 @@ extension UniverseSearchViewController {
             self.selectedSquareView.isHidden = false
             self.selectedSquareView.isAccessibilityElement = true
             
-//추후 사용예정 주석
-//            self.selectedSquareView.accessibilityLabel = planetNameDict[name] ?? name
+            // 추후 사용예정 주석
+            // self.selectedSquareView.accessibilityLabel = planetNameDict[name] ?? name
         }
     }
     
     // 검색 시 화살표 레이아웃 설정
     private func setArrowLayout(point: CGPoint, locatedBehind: Bool = false) {
-            var radian = locatedBehind ? atan2(circleCenter.y - point.y, point.x - circleCenter.x)
-            + .pi : atan2(circleCenter.y - point.y, point.x - circleCenter.x)
-            var degree = radian.radiansToDegree
-            
-            if locatedBehind {
-                if degree > 45 && degree <= 90 {
-                    degree = 45
-                } else if degree > 90 && degree < 135 {
-                    degree = 135
-                } else if degree > 225 && degree < 270 {
-                    degree = 225
-                } else if degree < 315 && degree >= 270 {
-                    degree = 315
-                }
-                radian = degree.degreeToRadians
+        var radian = locatedBehind ? atan2(circleCenter.y - point.y, point.x - circleCenter.x)
+        + .pi : atan2(circleCenter.y - point.y, point.x - circleCenter.x)
+        var degree = radian.radiansToDegree
+        
+        if locatedBehind {
+            if degree > 45 && degree <= 90 {
+                degree = 45
+            } else if degree > 90 && degree < 135 {
+                degree = 135
+            } else if degree > 225 && degree < 270 {
+                degree = 225
+            } else if degree < 315 && degree >= 270 {
+                degree = 315
             }
-            
-            let dx = screenWidth / 3  * cos(radian)
-            let dy = screenWidth / 3  * sin(radian)
-            let arrowPosition = CGPoint(x: circleCenter.x + dx, y: circleCenter.y - dy)
-            
-            DispatchQueue.main.async {
-                self.guideArrowView.transform = CGAffineTransform(rotationAngle: -radian)
-                self.guideArrowView.layer.position = arrowPosition
-                self.guideArrowView.isHidden = false
-            }
-            
+            radian = degree.degreeToRadians
         }
+        
+        let dx = screenWidth / 3  * cos(radian)
+        let dy = screenWidth / 3  * sin(radian)
+        let arrowPosition = CGPoint(x: circleCenter.x + dx, y: circleCenter.y - dy)
+        
+        DispatchQueue.main.async {
+            self.guideArrowView.transform = CGAffineTransform(rotationAngle: -radian)
+            self.guideArrowView.layer.position = arrowPosition
+            self.guideArrowView.isHidden = false
+        }
+        
+    }
     
     // 화살표 숨김 설정
     private func setArrowHidden() {
@@ -465,13 +465,15 @@ extension UniverseSearchViewController {
     }
 }
 
+// MARK: - 탐색 / 검색 모드 기능
+
 extension UniverseSearchViewController {
     // MARK: - 탐색 모드 기능
     private func explore() {
         var detectNode: SCNNode?
         var nodeCenter: CGPoint = .zero
         var minDistance: CGFloat = screenHeight
-
+        
         guard let pointOfView = sceneView.pointOfView else { return }
         let detectNodes = sceneView.nodesInsideFrustum(of: pointOfView) // 화면에 들어온 노드 리스트
         
@@ -479,7 +481,7 @@ extension UniverseSearchViewController {
             let nodePosition = sceneView.projectPoint(node.position)
             let nodeScreenPos = nodePosition.toCGPoint()
             let distance = circleCenter.distanceTo(nodeScreenPos)
-
+            
             // 원 안에 들어온 가장 짧은 거리, 노드, 화면상의 위치 저장
             if distance < screenWidth / 3 && distance < minDistance {
                 detectNode = node
@@ -487,12 +489,12 @@ extension UniverseSearchViewController {
                 minDistance = distance
             }
         }
-
+        
         if let detectNode = detectNode {
             // 원 안에 들어온 노드 존재했을 때
             guard let planetName = detectNode.name else { return }
             guard let name = planetNameDict[planetName] else { return }
-
+            
             let nodeOrigin = CGPoint(x: nodeCenter.x - screenWidth / 11.3, y: nodeCenter.y - screenWidth / 11.3)
             setDetectedLayout(name: name, point: nodeOrigin)
             selectedExploreSoundPlay(soundPlayer: planetObjectSound, selectedName: planetName)
@@ -511,7 +513,7 @@ extension UniverseSearchViewController {
         let distanceToCenter = circleCenter.distanceTo(nodeScreenPos)
         
         selectModeSoundPlay(soundPlayer: planetObjectSound, selectedName: name)
-
+        
         if nodePosition.z >= 1 {
             // 찾는 노드가 뒤에 있을 때
             setNotDetectedLayout()


### PR DESCRIPTION
## 관련 이슈
#74 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->


## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] 방위 이넘 작성
- [x] 안내한 방위 저장
- [x] 현재 방위와 비교 후 이웃한 방위를 벗어났을 때 announce

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

https://user-images.githubusercontent.com/58019653/203501789-d52e7c00-06af-4a0e-8f55-30d7d13f354a.mp4


## 리뷰포인트
* Cardinal enum을 추가하고 Mode enum과 함께 extension으로 아래로 이동했습니다. [링크](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-TARS/compare/feat/74-search-guide-voice?expand=1#diff-4ddb4e5a7efbb88c1ed06e9f7bc9213399e73aa38a057ecbb29998a7c0514dd0R382-R414)
* 행성이 내 핸드폰 기준 뒤에 있을 때 위, 아래로 화살표를 위치시키지 않도록 막았습니다. [링크](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-TARS/compare/feat/74-search-guide-voice?expand=1#diff-4ddb4e5a7efbb88c1ed06e9f7bc9213399e73aa38a057ecbb29998a7c0514dd0R328-R344)
* 안내 음성이 나간 방위를 저장하고 현재 방위와 비교해서 이웃한 방위를 벗어났을 때 voiceover로 현재 위치를 announce 하도록 했습니다. [7725ccf](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-TARS/commit/7725ccfc23a1edeafddaa57c3a466f3856e2e96c), [b91c794](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-TARS/commit/b91c79459b8ce7f39886aaf2f8102f3619d42b2c)
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->


## Reference
<!-- 참고한 자료를 작성해주세요 -->
- https://developer.apple.com/documentation/uikit/uiaccessibility/1615194-post
- https://www.hackingwithswift.com/example-code/language/how-to-convert-radians-to-degrees

## Checklist
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인


